### PR TITLE
Upgrade `mdsvex` and specify as a direct dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The easiest way to get started is to use `createConfig` to create a base `svelte
 
 ### `createConfig`
 
-Using `createConfig` requires `mdsvex` and `svelte-preprocess` to be installed.
+Using `createConfig` requires `svelte-preprocess` to be installed.
 
 ```bash
-pnpm i -D mdsvex svelte-preprocess
+pnpm i -D svelte-preprocess
 ```
 
 **Minimal**
@@ -80,7 +80,7 @@ interface CreateConfigOptions extends SvelteKitConfig {
    *   smartypants: false
    * }
    */
-  mdsvexOptions?: Record<string, any>;
+  mdsvexOptions?: MdsvexOptions;
 
   /**
    * Specify the SvelteKit adapter.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@sveltejs/kit": "next",
     "@types/node": "^17.0.13",
-    "mdsvex": "^0.9.8",
+    "mdsvex": "^0.10.5",
     "prettier": "^2.5.1",
     "svelte": "^3.46.3",
     "svelte-preprocess": "^4.10.2",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "format": "prettier --ignore-path \".gitignore\" --write \"./**/*.{md,ts}\"",
     "prepack": "tsc"
   },
+  "dependencies": {
+    "mdsvex": "^0.10.5"
+  },
   "devDependencies": {
     "@sveltejs/kit": "next",
     "@types/node": "^17.0.13",
-    "mdsvex": "^0.10.5",
     "prettier": "^2.5.1",
     "svelte": "^3.46.3",
     "svelte-preprocess": "^4.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,10 +11,12 @@ specifiers:
   vite: ^2.7.13
   vitest: ^0.2.5
 
+dependencies:
+  mdsvex: 0.10.5_svelte@3.46.3
+
 devDependencies:
   '@sveltejs/kit': 1.0.0-next.251_svelte@3.46.3
   '@types/node': 17.0.13
-  mdsvex: 0.10.5_svelte@3.46.3
   prettier: 2.5.1
   svelte: 3.46.3
   svelte-preprocess: 4.10.2_svelte@3.46.3+typescript@4.5.5
@@ -99,7 +101,7 @@ packages:
 
   /@types/unist/2.0.6:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
-    dev: true
+    dev: false
 
   /assertion-error/1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
@@ -424,7 +426,7 @@ packages:
       prismjs: 1.26.0
       svelte: 3.46.3
       vfile-message: 2.0.4
-    dev: true
+    dev: false
 
   /min-indent/1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -508,12 +510,12 @@ packages:
 
   /prism-svelte/0.4.7:
     resolution: {integrity: sha512-yABh19CYbM24V7aS7TuPYRNMqthxwbvx6FF/Rw920YbyBWO3tnyPIqRMgHuSVsLmuHkkBS1Akyof463FVdkeDQ==}
-    dev: true
+    dev: false
 
   /prismjs/1.26.0:
     resolution: {integrity: sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==}
     engines: {node: '>=6'}
-    dev: true
+    dev: false
 
   /resolve/1.22.0:
     resolution: {integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==}
@@ -675,14 +677,14 @@ packages:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
     dependencies:
       '@types/unist': 2.0.6
-    dev: true
+    dev: false
 
   /vfile-message/2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
     dependencies:
       '@types/unist': 2.0.6
       unist-util-stringify-position: 2.0.3
-    dev: true
+    dev: false
 
   /vite/2.7.13:
     resolution: {integrity: sha512-Mq8et7f3aK0SgSxjDNfOAimZGW9XryfHRa/uV0jseQSilg+KhYDSoNb9h1rknOy6SuMkvNDLKCYAYYUMCE+IgQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,7 @@ lockfileVersion: 5.3
 specifiers:
   '@sveltejs/kit': next
   '@types/node': ^17.0.13
-  mdsvex: ^0.9.8
+  mdsvex: ^0.10.5
   prettier: ^2.5.1
   svelte: ^3.46.3
   svelte-preprocess: ^4.10.2
@@ -14,7 +14,7 @@ specifiers:
 devDependencies:
   '@sveltejs/kit': 1.0.0-next.251_svelte@3.46.3
   '@types/node': 17.0.13
-  mdsvex: 0.9.8_svelte@3.46.3
+  mdsvex: 0.10.5_svelte@3.46.3
   prettier: 2.5.1
   svelte: 3.46.3
   svelte-preprocess: 4.10.2_svelte@3.46.3+typescript@4.5.5
@@ -414,8 +414,8 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /mdsvex/0.9.8_svelte@3.46.3:
-    resolution: {integrity: sha512-5QvThjRKoKkGH00qdHxLZ5ROd80RgGiJvM2B9opeFreaiGFTLoKKFUgEBCslLrwM24cVGJLmIM3rR83OFDf3tQ==}
+  /mdsvex/0.10.5_svelte@3.46.3:
+    resolution: {integrity: sha512-/B23WZn5Vjrjh7Qp2YsOXLkU9YFm59IEylKNXC10o05ZaCP4LNv32tGXKP6aEssss6hk/LdISJuneELHFIS2pQ==}
     peerDependencies:
       svelte: 3.x
     dependencies:

--- a/src/create-config.ts
+++ b/src/create-config.ts
@@ -7,13 +7,13 @@
  *  - which `@sveltejs/adapter-*` to use, if any -> dynamically import it
  *
  * 2. Should `mdsvex` be installed by default?
- * 3. Strongly type `mdsvex` options.
  */
 
 import path from "path";
 import { preprocessReadme, pluginReadme } from "./integrations";
 import { mdsvex } from "mdsvex";
 import preprocess from "svelte-preprocess";
+import type { MdsvexOptions } from "mdsvex";
 import type { Config as SvelteKitConfig, Adapter } from "@sveltejs/kit";
 import type { AliasOptions } from "vite";
 
@@ -35,7 +35,7 @@ interface CreateConfigOptions extends SvelteKitConfig {
    *   smartypants: false
    * }
    */
-  mdsvexOptions?: Record<string, any>;
+  mdsvexOptions?: MdsvexOptions;
 
   /**
    * Specify the SvelteKit adapter.


### PR DESCRIPTION
**Features**

- upgrade `mdsvex` to version 0.10.5
- type `createConfig.mdsvexOptions` using `MdsvexOptions` interface
- specify `mdsvex` as a direct dependency