### PR TITLE
Target ES6 when building the library

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "lib",
     "skipLibCheck": true,
     "strict": true,
-    "target": "ESNext"
+    "target": "ES6"
   },
   "include": ["src/*"]
 }


### PR DESCRIPTION
**Breaking Changes**

- target ES6 instead of ESNext when building the library