### PR TITLE
fix(create-config): remove deprecated `target` option

### DIFF
--- a/src/create-config.ts
+++ b/src/create-config.ts
@@ -100,7 +100,6 @@ export const createConfig: (config: CreateConfigOptions) => SvelteKitConfig = (c
     ].filter(Boolean),
     ...config,
     kit: {
-      target: "#svelte",
       adapter: config?.adapter,
       files: config?.files,
       ...config?.kit,


### PR DESCRIPTION
SvelteKit v1.0.0-next.257 deprecated the `kit.target` field.