### PR TITLE
feat: format README, support base URL

### DIFF
--- a/src/create-vite-config.ts
+++ b/src/create-vite-config.ts
@@ -40,7 +40,12 @@ export const createViteConfig: CreateViteConfig = (options) => {
       }),
       svelte({
         extensions: [".svelte", ".md"],
-        preprocess: [typescript(), preprocessReadme({ base: options?.base })],
+        preprocess: [
+          typescript(),
+          preprocessReadme({
+            base: options?.base ?? ".",
+          }),
+        ],
       }),
       pluginReadme(),
     ],

--- a/src/create-vite-config.ts
+++ b/src/create-vite-config.ts
@@ -40,7 +40,7 @@ export const createViteConfig: CreateViteConfig = (options) => {
       }),
       svelte({
         extensions: [".svelte", ".md"],
-        preprocess: [typescript(), preprocessReadme()],
+        preprocess: [typescript(), preprocessReadme({ base: options?.base })],
       }),
       pluginReadme(),
     ],

--- a/src/plugin-index.ts
+++ b/src/plugin-index.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from "vite";
-import { CreateViteConfigOptions } from "./create-vite-config";
+import type { CreateViteConfigOptions } from "./create-vite-config";
 import { github_styles } from "./styles/github-markdown";
 import { sveldoc_styles } from "./styles/sveldoc";
 import { getPackageJson } from "./utils/get-package-json";

--- a/src/plugin-readme.ts
+++ b/src/plugin-readme.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import prettier from "prettier";
 import type { Plugin } from "vite";
 import { fdir } from "fdir";
 import type { PathsOutput } from "fdir";
@@ -53,7 +54,10 @@ export const pluginReadme = (): Plugin => {
         noEval: true,
       });
 
-      fs.writeFileSync(filename, transformed.code);
+      fs.writeFileSync(
+        filename,
+        prettier.format(transformed.code, { parser: "markdown" })
+      );
     },
   };
 };

--- a/src/preprocess-readme.ts
+++ b/src/preprocess-readme.ts
@@ -1,12 +1,23 @@
 import type { SveltePreprocessor } from "svelte/types/compiler/preprocess";
+import type { CreateViteConfigOptions } from "./create-vite-config";
 import { processReadme } from "./process-readme";
 import { match } from "./utils/match";
 
-export const preprocessReadme: SveltePreprocessor<"markup"> = () => {
+interface PreprocessReadmeOptions
+  extends Pick<CreateViteConfigOptions, "base"> {}
+
+export const preprocessReadme: SveltePreprocessor<
+  "markup",
+  PreprocessReadmeOptions
+> = (options) => {
   return {
     markup: ({ content: source, filename }) => {
       if (!filename || !match.readmeFile(filename)) return;
-      return processReadme({ source, filename });
+      return processReadme({
+        source,
+        filename,
+        base: options?.base!,
+      });
     },
   };
 };

--- a/src/process-readme.ts
+++ b/src/process-readme.ts
@@ -50,7 +50,7 @@ interface ProcessReadmeOptions {
 
 export const processReadme = async (options: ProcessReadmeOptions) => {
   const { source, filename, noEval } = options;
-  const base_url = options?.base ?? "/";
+  const base_url = options?.base ?? ".";
 
   let cleaned = "";
   let open = false;
@@ -68,10 +68,7 @@ export const processReadme = async (options: ProcessReadmeOptions) => {
     cleaned = marked.parse(cleaned);
   }
 
-  let script_module_unique_lines = new Set();
-  let script_unique_lines = new Set();
   let dependencies = new Set<string>();
-  let styles = "";
   let lines_code = "";
 
   for await (let line of cleaned.split("\n")) {
@@ -102,23 +99,18 @@ export const processReadme = async (options: ProcessReadmeOptions) => {
       }
 
       const source = fs.readFileSync(path_component, "utf-8");
-      const { html, css, script, module } = (
-        await parseComponent({ source, filename })
-      ).parsed;
+      const { html, css } = (await parseComponent({ source, filename })).parsed;
 
-      let source_modified = source;
+      let source_modified = path_options.blocks !== null ? "" : source;
 
-      if (path_options.blocks !== null) {
-        source_modified = "";
-
-        if (path_options.blocks.includes("markup")) {
+      path_options.blocks?.forEach((block) => {
+        if (block === "markup") {
           source_modified += html;
         }
-
-        if (path_options.blocks.includes("style")) {
-          source_modified += `<style>\n${css}\n</style>`;
+        if (block === "style" && css) {
+          source_modified += `<style>\n${css}\n<\/style>`;
         }
-      }
+      });
 
       const source_formatted = prettier.format(source_modified, {
         parser: "svelte",
@@ -129,10 +121,6 @@ export const processReadme = async (options: ProcessReadmeOptions) => {
         "svelte"
       );
 
-      module.forEach((line) => script_module_unique_lines.add(line));
-      script.forEach((line) => script_unique_lines.add(line));
-      styles += css;
-
       let line_modified = "\n";
 
       if (noEval) {
@@ -142,7 +130,9 @@ export const processReadme = async (options: ProcessReadmeOptions) => {
           line_modified += `
             <iframe
               title="${name} example"
-              src="${base_url}examples/${base}.html"
+              src="${base_url}${
+            base_url.endsWith("/") ? "" : "/"
+          }examples/${base}.html"
               loading="lazy"
               ${
                 path_options.height

--- a/src/process-readme.ts
+++ b/src/process-readme.ts
@@ -45,10 +45,12 @@ interface ProcessReadmeOptions {
   source: string;
   filename: string;
   noEval?: boolean;
+  base?: string;
 }
 
 export const processReadme = async (options: ProcessReadmeOptions) => {
   const { source, filename, noEval } = options;
+  const base_url = options?.base ?? "/";
 
   let cleaned = "";
   let open = false;
@@ -140,7 +142,7 @@ export const processReadme = async (options: ProcessReadmeOptions) => {
           line_modified += `
             <iframe
               title="${name} example"
-              src="/examples/${base}.html"
+              src="${base_url}examples/${base}.html"
               loading="lazy"
               ${
                 path_options.height

--- a/template/README.md
+++ b/template/README.md
@@ -28,14 +28,47 @@ This is some text.
 www.example.com
 
 <!-- example-start examples/Basic.svelte -->
+
+```svelte
+<script>
+  import Counter from "svelte-component";
+
+  let count = 10;
+</script>
+
+<Counter bind:count />
+
+This is the current count: {count}
+```
+
 <!-- example-end -->
 
 <!-- example-start examples/Basic.svelte blocks:markup -->
+
+```svelte
+<Counter bind:count />
+
+This is the current count: {count}
+```
+
 <!-- example-end -->
 
 This is an example where the code is not evaluated:
 
 <!-- example-start examples/Basic.svelte no-eval -->
+
+```svelte
+<script>
+  import Counter from "svelte-component";
+
+  let count = 10;
+</script>
+
+<Counter bind:count />
+
+This is the current count: {count}
+```
+
 <!-- example-end -->
 
 ### Events
@@ -44,11 +77,48 @@ This is some text [git@github.com:metonym/sveldoc.git](git@github.com:metonym/sv
 www.example.com
 
 <!-- example-start examples/Events.svelte height:400px -->
+
+```svelte
+<script>
+  import Counter from "svelte-component";
+
+  let count = 100;
+</script>
+
+<Counter
+  bind:count
+  on:click={() => {
+    console.log("on:click");
+  }}
+/>
+
+<strong>{count}</strong>
+
+<style>
+  strong {
+    color: red;
+  }
+</style>
+```
+
 <!-- example-end -->
 
 ### Style
 
 <!-- example-start examples/Style.svelte blocks:markup,style -->
+
+```svelte
+<div>
+  <Counter count={4} />
+</div>
+
+<style>
+  div {
+    outline: 1px solid blue;
+  }
+</style>
+```
+
 <!-- example-end -->
 
 ## API

--- a/template/vite.config.js
+++ b/template/vite.config.js
@@ -1,5 +1,3 @@
 import { createViteConfig } from "sveldoc";
 
-export default createViteConfig({
-  base: "/svelte-component/",
-});
+export default createViteConfig();

--- a/template/vite.config.js
+++ b/template/vite.config.js
@@ -1,3 +1,5 @@
 import { createViteConfig } from "sveldoc";
 
-export default createViteConfig();
+export default createViteConfig({
+  base: "/svelte-component/",
+});

--- a/tests/__snapshots__/process-readme.test.ts.snap
+++ b/tests/__snapshots__/process-readme.test.ts.snap
@@ -13,7 +13,7 @@ exports[`processReadme >  1`] = `
 
             <iframe
               title=\\"Button example\\"
-              src=\\"/examples/Button.svelte.html\\"
+              src=\\"./examples/Button.svelte.html\\"
               loading=\\"lazy\\"
               
             /><pre><code>{@html \`<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>script</span><span class=\\"token punctuation\\">></span></span><span class=\\"token script\\"><span class=\\"token language-javascript\\">
@@ -45,7 +45,7 @@ exports[`processReadme >  1`] = `
 
             <iframe
               title=\\"Heading example\\"
-              src=\\"/examples/Heading.svelte.html\\"
+              src=\\"./examples/Heading.svelte.html\\"
               loading=\\"lazy\\"
               
             /><pre><code>{@html \`<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>script</span><span class=\\"token punctuation\\">></span></span><span class=\\"token script\\"><span class=\\"token language-javascript\\">
@@ -151,7 +151,7 @@ exports[`processReadme >  3`] = `
 
             <iframe
               title=\\"Button example\\"
-              src=\\"/examples/Button.svelte.html\\"
+              src=\\"./examples/Button.svelte.html\\"
               loading=\\"lazy\\"
               
             /><pre><code>{@html \`<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>script</span><span class=\\"token punctuation\\">></span></span><span class=\\"token script\\"><span class=\\"token language-javascript\\">
@@ -183,7 +183,7 @@ exports[`processReadme >  3`] = `
 
             <iframe
               title=\\"Heading example\\"
-              src=\\"/examples/Heading.svelte.html\\"
+              src=\\"./examples/Heading.svelte.html\\"
               loading=\\"lazy\\"
               
             /><pre><code>{@html \`<span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>script</span><span class=\\"token punctuation\\">></span></span><span class=\\"token script\\"><span class=\\"token language-javascript\\">


### PR DESCRIPTION
- use Prettier to format `README.md` after building app
- support base URL if specified; default to being relative