### PR TITLE
fix(base): correctly set default vite base value

### DIFF
--- a/src/create-vite-config.ts
+++ b/src/create-vite-config.ts
@@ -24,9 +24,11 @@ type CreateViteConfig = (options?: CreateViteConfigOptions) => UserConfig & {
 
 export const createViteConfig: CreateViteConfig = (options) => {
   const resetStyles = options?.resetStyles === true;
+  const base = options?.base ?? "./";
 
   return {
     ...options,
+    base,
     resolve: {
       ...options?.resolve,
       alias: {
@@ -40,12 +42,7 @@ export const createViteConfig: CreateViteConfig = (options) => {
       }),
       svelte({
         extensions: [".svelte", ".md"],
-        preprocess: [
-          typescript(),
-          preprocessReadme({
-            base: options?.base ?? ".",
-          }),
-        ],
+        preprocess: [typescript(), preprocessReadme({ base })],
       }),
       pluginReadme(),
     ],

--- a/src/process-readme.ts
+++ b/src/process-readme.ts
@@ -50,7 +50,7 @@ interface ProcessReadmeOptions {
 
 export const processReadme = async (options: ProcessReadmeOptions) => {
   const { source, filename, noEval } = options;
-  const base_url = options?.base ?? ".";
+  const base_url = options?.base ?? "./";
 
   let cleaned = "";
   let open = false;
@@ -130,9 +130,7 @@ export const processReadme = async (options: ProcessReadmeOptions) => {
           line_modified += `
             <iframe
               title="${name} example"
-              src="${base_url}${
-            base_url.endsWith("/") ? "" : "/"
-          }examples/${base}.html"
+              src="${base_url}examples/${base}.html"
               loading="lazy"
               ${
                 path_options.height


### PR DESCRIPTION
`base` wasn't being set on the created Vite config.

Also, `"."` is an invalid value for `base`. Instead, default to `"./"`.